### PR TITLE
Add generic types to improve type safety

### DIFF
--- a/src/Modalize.tsx
+++ b/src/Modalize.tsx
@@ -13,7 +13,8 @@ const AnimatedFlatList = Animated.createAnimatedComponent(FlatList);
 const AnimatedSectionList = Animated.createAnimatedComponent(SectionList);
 const THRESHOLD = 150;
 
-export default class Modalize extends React.Component<IProps, IState> {
+export default class Modalize<FlatListItem = any, SectionListItem = any>
+  extends React.Component<IProps<FlatListItem, SectionListItem>, IState> {
 
   static defaultProps = {
     handlePosition: 'outside',
@@ -47,7 +48,7 @@ export default class Modalize extends React.Component<IProps, IState> {
   private modalOverlayTap: React.RefObject<TapGestureHandler> = React.createRef();
   private willCloseModalize: boolean = false;
 
-  constructor(props: IProps) {
+  constructor(props: IProps<FlatListItem, SectionListItem>) {
     super(props);
 
     const fullHeight = isIos() ? screenHeight : screenHeight - 10;

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -19,7 +19,7 @@ export interface IConfigProps {
   spring: ISpringProps;
 }
 
-export interface IProps {
+export interface IProps<FlatListItem = any, SectionListItem = any> {
   /**
    * A React component that will define the content of the modal.
    */
@@ -117,12 +117,12 @@ export interface IProps {
   /*
    * An object to pass any of the react-native FlatList's props.
    */
-  flatListProps?: FlatListProps<any>;
+  flatListProps?: FlatListProps<FlatListItem>;
 
   /*
    * An object to pass any of the react-native SectionList's props.
    */
-  sectionListProps?: SectionListProps<any>;
+  sectionListProps?: SectionListProps<SectionListItem>;
 
   /**
    * A header component outside of the ScrollView, on top of the modal.


### PR DESCRIPTION
I've added generic types to improve type safety on `Modalize` component, my suggestions are described on #54. I've run the `lint` and `build` command and everything seems fine. 

This PR only breaks ts projects that rely on the `any` type of flat/section list items, so technically this is a breaking change... should I bump the lib version too?

This closes #54 