### PR TITLE
Update RNN example to RN 0.59.9

### DIFF
--- a/examples/react-native-navigation/package.json
+++ b/examples/react-native-navigation/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "faker": "4.1.0",
     "react": "16.8.3",
-    "react-native": "0.59.8",
+    "react-native": "0.59.9",
     "react-native-gesture-handler": "1.2.1",
     "react-native-modalize": "file:../../src",
     "react-native-navigation": "2.20.2"


### PR DESCRIPTION
In order to fix an issue with Xcode 11 on RN 0.59.8, we have to update it to 0.59.9.

<img height="500" src="https://user-images.githubusercontent.com/7189823/66655089-7c8d3300-ec09-11e9-853f-404fc64b9407.png" />
