### PR TITLE
Prevent flickering with adjustToContentHeight

### DIFF
--- a/src/Modalize.tsx
+++ b/src/Modalize.tsx
@@ -130,13 +130,17 @@ export default class Modalize<FlatListItem = any, SectionListItem = any>
   }
 
   public open = (): void => {
-    const { onOpen } = this.props;
+    const { adjustToContentHeight, onOpen } = this.props;
 
     if (onOpen) {
       onOpen();
     }
 
-    this.onAnimateOpen();
+    if (!adjustToContentHeight || this.contentAlreadyCalculated) {
+      this.onAnimateOpen();
+    } else {
+      this.setState({ isVisible: true });
+    }
   }
 
   public close = (): void => {
@@ -297,6 +301,7 @@ export default class Modalize<FlatListItem = any, SectionListItem = any>
       modalHeight: contentHeight - this.handleHeight,
     }, () => {
       this.contentAlreadyCalculated = true;
+      this.onAnimateOpen();
     });
   }
 


### PR DESCRIPTION
Fixes #46.

Currently, with `adjustToContentHeight` we have a flickering effect because the layout has to be rendered to know the exact height.

To prevent this, we could delay the animation once the layout has been fully rendered. Then, once we know the height, we can start the translation animation.