### PR TITLE
Correct start position of "alwaysOpen" modal

### DIFF
--- a/src/Modalize.tsx
+++ b/src/Modalize.tsx
@@ -292,7 +292,7 @@ export default class Modalize<FlatListItem = any, SectionListItem = any>
       this.contentAlreadyCalculated
     ) {
       if (modalHeight <= nativeEvent.layout.height) {
-        this.onAnimateOpen();
+        this.onAnimateOpen(this.props.alwaysOpen);
       }
 
       return;


### PR DESCRIPTION
`this.onAnimateOpen(this.props.alwaysOpen)` was being called during `componentDidMount` which opened the modal to the intended place but `onContentViewLayout` was also being called and called `this.onAnimateOpen()` without the prop, so the modal would then open to it’s full height.

```js
// onContentViewLayout

if (
  !adjustToContentHeight ||
  modalHeight <= nativeEvent.layout.height ||
  snapPoint ||
  this.contentAlreadyCalculated
) {
  if (modalHeight <= nativeEvent.layout.height) {
    this.onAnimateOpen(this.props.alwaysOpen);
  }

  return;
}
```

It seems to also be fixed if you make the height check the following, with no need to pass the prop but at this time to fully grasp what negative effects that may have elsewhere.

```js
if (modalHeight < nativeEvent.layout.height) {
  this.onAnimateOpen();
}
``` 

Fixes #92 