### PR TITLE
Exposed dragToss parameter as part a props

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -384,6 +384,7 @@ export class Modalize<FlatListItem = any, SectionListItem = any> extends React.C
       adjustToContentHeight,
       alwaysOpen,
       closeAnimationConfig,
+      dragToss = 0.05,
     } = this.props;
     const { timing } = closeAnimationConfig!;
     const { lastSnap, modalHeight, overlay } = this.state;
@@ -396,7 +397,6 @@ export class Modalize<FlatListItem = any, SectionListItem = any> extends React.C
       let destSnapPoint = 0;
 
       if (snapPoint || alwaysOpen) {
-        const dragToss = 0.05;
         const endOffsetY = lastSnap + toValue + dragToss * velocityY;
 
         this.snaps.forEach((snap: number) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -59,6 +59,7 @@ export class Modalize<FlatListItem = any, SectionListItem = any> extends React.C
     closeAnimationConfig: {
       timing: { duration: 280, easing: Easing.ease },
     },
+    dragToss: 0.05,
   };
 
   private snaps: number[] = [];

--- a/src/options.ts
+++ b/src/options.ts
@@ -37,6 +37,11 @@ export interface IProps<FlatListItem = any, SectionListItem = any> {
   children?: React.ReactNode;
 
   /**
+   * A number that determines the determines the momentum of the scroll required.
+   */
+  dragToss?: number;
+
+  /**
    * A number that will enable the snapping feature and create an intermediate point before opening the modal to full screen.
    */
   snapPoint?: number;


### PR DESCRIPTION
User can now specify their own override for `dragToss` constant value.

Reasoning: Specifying `dragToss = 0.15` helps us do a "fast swipe" to open/close in certain use cases. Currently code is a fixed value of `dragToss = 0.05`

For backwards compatibility, we get this value from props, if not specified, it's set to the existing default value of `dragToss = 0.05`.