### PR TITLE
Remove back press listener on unmount

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -158,6 +158,7 @@ export class Modalize<FlatListItem = any, SectionListItem = any> extends React.C
   }
 
   componentWillUnmount() {
+    BackHandler.removeEventListener('hardwareBackPress', this.onBackPress);
     Keyboard.removeListener('keyboardDidShow', this.onKeyboardShow);
     Keyboard.removeListener('keyboardDidHide', this.onKeyboardHide);
   }


### PR DESCRIPTION
This should fix the #111, where one could do: `cond ? <Modalize ...> : null`, and a `cond=false` could cause the modalize to keep listening to back press events