### PR TITLE
Open modal at the top

### DIFF
--- a/docs/PROPSMETHODS.md
+++ b/docs/PROPSMETHODS.md
@@ -100,6 +100,13 @@ Object to change the close animations. You can either pass a timing (`Animated.t
 | -------- | -------- | ------------------------------------------ |
 | object   | No       | `{ spring: { speed: 14, bounciness: 5 } }` |
 
+### `threshold`
+Number of pixels that the user must drag the modal before snapping to another position
+
+| Type     | Required | Default                                    |
+| -------- | -------- | ------------------------------------------ |
+| number   | No       | `150` |
+
 ### `adjustToContentHeight`
 
 Shrink the modal to your content's height.
@@ -271,17 +278,17 @@ Callback function when the modal reaches the `top` (modal/screen height) or `ini
 
 ### `open()`
 
-The method to open the modal.
+The method to open the modal. If have defined the `snapPoint` prop, then setting `initial` will open the modal at the snapPoint, while setting `top` will open the modal in full screen.
 
-| Type     | Required  |
-| -------- | --------- |
-| function | Yes       |
+| Type     | Required  | Default
+| -------- | --------- | -------
+| function(position: 'initial' \| 'top') | No | `initial`
 
 ### `close()`
 
 The method to close the modal. You don't need to call it to dismiss the modal, since you can swipe down to dismiss.
 
-?> If you are using `alwaysOpen` props, you can supply a `dest` argument to the `close` method to reset it to the intial position  `close('alwaysOpen')`, and avoiding to close it completely.
+If you are using `alwaysOpen` props, you can supply a `dest` argument to the `close` method to reset it to the intial position  `close('alwaysOpen')`, and avoiding to close it completely.
 
 | Type                                       | Required |
 | ------------------------------------------ | -------- |

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,7 +36,6 @@ const { height: screenHeight } = Dimensions.get('window');
 const AnimatedKeyboardAvoidingView = Animated.createAnimatedComponent(KeyboardAvoidingView);
 const AnimatedFlatList = Animated.createAnimatedComponent(FlatList);
 const AnimatedSectionList = Animated.createAnimatedComponent(SectionList);
-const THRESHOLD = 150;
 
 export class Modalize<FlatListItem = any, SectionListItem = any> extends React.Component<
   IProps<FlatListItem, SectionListItem>,
@@ -67,6 +66,7 @@ export class Modalize<FlatListItem = any, SectionListItem = any> extends React.C
       timing: { duration: 280, easing: Easing.ease },
     },
     dragToss: 0.05,
+    threshold: 150,
   };
 
   private snaps: number[] = [];
@@ -163,14 +163,14 @@ export class Modalize<FlatListItem = any, SectionListItem = any> extends React.C
     Keyboard.removeListener('keyboardDidHide', this.onKeyboardHide);
   }
 
-  public open = (): void => {
+  public open = (position: 'initial' | 'top' = 'initial'): void => {
     const { onOpen } = this.props;
 
     if (onOpen) {
       onOpen();
     }
 
-    this.onAnimateOpen();
+    this.onAnimateOpen(undefined, position);
   };
 
   public close = (dest: 'alwaysOpen' | 'default' = 'default'): void => {
@@ -242,7 +242,7 @@ export class Modalize<FlatListItem = any, SectionListItem = any> extends React.C
     };
   }
 
-  private onAnimateOpen = (alwaysOpen?: number): void => {
+  private onAnimateOpen = (alwaysOpen?: number, position?: 'initial' | 'top'): void => {
     const {
       onOpened,
       snapPoint,
@@ -255,6 +255,8 @@ export class Modalize<FlatListItem = any, SectionListItem = any> extends React.C
     const { overlay, modalHeight } = this.state;
     const toValue = alwaysOpen
       ? (modalHeight || 0) - alwaysOpen
+      : position === 'top'
+      ? 0
       : snapPoint
       ? (modalHeight || 0) - snapPoint
       : 0;
@@ -292,7 +294,9 @@ export class Modalize<FlatListItem = any, SectionListItem = any> extends React.C
       }
 
       if (onPositionChange) {
-        if (alwaysOpen || snapPoint) {
+        if (position === 'top') {
+          this.modalPosition = 'top';
+        } else if (alwaysOpen || snapPoint) {
           this.modalPosition = 'initial';
         } else {
           this.modalPosition = 'top';
@@ -449,7 +453,7 @@ export class Modalize<FlatListItem = any, SectionListItem = any> extends React.C
           }
         });
       } else if (
-        translationY > (adjustToContentHeight ? (modalHeight || 0) / 3 : THRESHOLD) &&
+        translationY > (adjustToContentHeight ? (modalHeight || 0) / 3 : this.props.threshold) &&
         this.beginScrollYValue === 0 &&
         !alwaysOpen
       ) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -114,6 +114,12 @@ export interface IProps<FlatListItem = any, SectionListItem = any> {
   dragToss: number;
 
   /**
+   * Number of pixels that the user must drag the modal before snapping to another position
+   * @default 150
+   */
+  threshold: number;
+
+  /**
    * Shrink the modal to your content's height.
    * @default false
    */


### PR DESCRIPTION
When the user has passed in `snapPoint` prop, it would be nice to give them the option to open the modal either at the snapPoint (initial) or full screen (top). 

This PR add a new parameter to the `open()` method that allows them to specify that option.

The constant `THRESHOLD` has also been converted into the `threshold` prop give the user more power to configure the panning behavior.