### PR TITLE
fix: FloatingComponent hierarchy for Android, update examples

### DIFF
--- a/examples/expo/src/components/modals/FlatList.js
+++ b/examples/expo/src/components/modals/FlatList.js
@@ -84,7 +84,7 @@ const s = StyleSheet.create({
   floating: {
     alignItems: 'center',
     justifyContent: 'center',
-    zIndex: 999,
+    zIndex: 9999,
 
     position: 'absolute',
     right: 20,

--- a/examples/react-native-navigation/src/screens/FlatList.js
+++ b/examples/react-native-navigation/src/screens/FlatList.js
@@ -94,7 +94,7 @@ const s = StyleSheet.create({
   floating: {
     alignItems: 'center',
     justifyContent: 'center',
-    zIndex: 999,
+    zIndex: 9999,
 
     position: 'absolute',
     right: 20,

--- a/examples/react-navigation/src/components/modals/FlatList.js
+++ b/examples/react-navigation/src/components/modals/FlatList.js
@@ -84,7 +84,7 @@ const s = StyleSheet.create({
   floating: {
     alignItems: 'center',
     justifyContent: 'center',
-    zIndex: 999,
+    zIndex: 9999,
 
     position: 'absolute',
     right: 20,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -846,9 +846,9 @@ export class Modalize<FlatListItem = any, SectionListItem = any> extends React.C
             )}
 
             {this.renderOverlay()}
-            {this.renderFloatingComponent()}
           </View>
         </TapGestureHandler>
+        {this.renderFloatingComponent()}
       </View>
     );
   };


### PR DESCRIPTION
Hi again!

Sorry about this issue, I didn't test initially on an Android device and my FloatingComponent was hidden behind the Modal.

Fixed it and examples as well.