### PR TITLE
Prevent overlay press closing alwaysOpen

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -508,7 +508,7 @@ const ModalizeBase = (
         onOverlayPress();
       }
 
-      const dest = !alwaysOpen ? 'alwaysOpen' : 'default';
+      const dest = !!alwaysOpen ? 'alwaysOpen' : 'default';
 
       handleClose(dest);
     }


### PR DESCRIPTION
In https://github.com/jeremybarbet/react-native-modalize/blob/569bd258e1f90e44e77f5eef3bb42dc34af582a4/src/index.tsx#L551 eslint removed an extra bang, meaning dist was not determined correctly and so alwaysOpen modal would close on overlay press