### PR TITLE
Docs: add missing word at callbacks section

### DIFF
--- a/docs/PROPS.md
+++ b/docs/PROPS.md
@@ -524,7 +524,7 @@ Callback function when the modal is closed.
 
 ### `onBackButtonPress`
 
-onBackButtonPress is called when the user taps the hardware back button on Android or the menu button on Apple TV. You can any function you want, but you will have to close the modal by yourself.
+onBackButtonPress is called when the user taps the hardware back button on Android or the menu button on Apple TV. You can pass any function you want, but you will have to close the modal by yourself.
 
 | Type     | Required |
 | -------- | -------- |


### PR DESCRIPTION
I noticed that there's a missing word at docs and just added it.