### PR TITLE
chore: utility hook for modalize

### DIFF
--- a/src/utils/use-modalize.ts
+++ b/src/utils/use-modalize.ts
@@ -1,0 +1,14 @@
+import { useCallback, useRef } from 'react';
+import { Modalize } from '../index';
+
+export const useModalize = () => {
+  const ref = useRef<Modalize>(null);
+
+  const close = useCallback(() => {
+    ref.current?.close();
+  }, []);
+
+  const open = useCallback(() => ref.current?.open(), []);
+
+  return { ref, open, close };
+};


### PR DESCRIPTION
I found myself writing the boilerplate in the diff again and again for a project with many modalize modals (thanks for all your hard work @jeremybarbet!). Thought others might find it useful too.

The usage in your component then becomes:

`const { ref, open, close } = useModalize()`