### PR TITLE
fix: adjustToContentHeight with alwaysOpen

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -901,7 +901,7 @@ const ModalizeBase = (
       s.modalize__content,
       modalStyle,
       {
-        height: modalHeightValue,
+        height: adjustToContentHeight ? undefined : modalHeightValue,
         maxHeight: endHeight,
         transform: [
           {


### PR DESCRIPTION
Fixing the problem with the hidden modal will use adjustToContentHeight with alwaysOpen, and keyboardAvoidingView now correct work

Closes #172