### PR TITLE
prevent dupe open/close calls

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -224,6 +224,8 @@ const ModalizeBase = (
     alwaysOpenValue: number | undefined,
     dest: TOpen = 'default',
   ): void => {
+    if (isVisible) return;
+
     const { timing, spring } = openAnimationConfig;
 
     (backButtonListenerRef as any).current = BackHandler.addEventListener(
@@ -305,6 +307,8 @@ const ModalizeBase = (
   };
 
   const handleAnimateClose = (dest: TClose = 'default'): void => {
+    if (!isVisible) return;
+
     const { timing, spring } = closeAnimationConfig;
     const lastSnapValue = snapPoint ? snaps[1] : 80;
     const toInitialAlwaysOpen = dest === 'alwaysOpen' && Boolean(alwaysOpen);


### PR DESCRIPTION
Current Behavior: If `<Modalize>` is already closed, and you call the `close` method, the `onClosed` callback function gets called. Similarly, when  `<Modalize>` is already opened, and you call the `open` method, the `onOpened` callback function gets called. This is undesirable because when the `onClosed`/`onOpened` callbacks get triggered, it gives you the impression that the modal was just closed/opened, which is not the case.

This PR will prevent the `onOpened` and `onClosed` callback functions from being called if the `<Modalize>` is already opened or closed respectively.

With this PR, the `onClose` and `onOpen` callbacks WILL still get triggered, which I'm not sure if that is desired. If requested, I can make a commit to also prevent `onClose` and `onOpen` from being triggered if the modal is already opened/closed.