### PR TITLE
RN v0.65 compatibility

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -883,13 +883,20 @@ const ModalizeBase = (
   }, [adjustToContentHeight, modalHeight, screenHeight]);
 
   React.useEffect(() => {
-    Keyboard.addListener('keyboardDidShow', handleKeyboardShow);
-    Keyboard.addListener('keyboardDidHide', handleKeyboardHide);
-
+    const subscriptions =[
+      Keyboard.addListener('keyboardDidShow', handleKeyboardShow),
+      Keyboard.addListener('keyboardDidHide', handleKeyboardHide)
+    ];
     return (): void => {
       backButtonListenerRef.current?.remove();
-      Keyboard.removeListener('keyboardDidShow', handleKeyboardShow);
-      Keyboard.removeListener('keyboardDidHide', handleKeyboardHide);
+      if (Keyboard.removeListener) {
+        Keyboard.removeListener('keyboardDidShow', handleKeyboardShow);
+        Keyboard.removeListener('keyboardDidHide', handleKeyboardHide);
+      } else {
+        for (const subscription in subscriptions) {
+          subscription.remove();
+        }
+      }
     };
   }, []);
 


### PR DESCRIPTION
# Summary
React Native 0.65 seems to not support Keyboard.removeListener anymore.  Technically it's "deprecated", but if you run

https://reactnative.dev/docs/keyboard

```typescript
console.log(Keyboard.removeListener);
```

...it produces `undefined`


## Test Plan
### What's required for testing (prerequisites)?
- Call `useKeyboard` within a component that gets destroyed, on React Native v0.65

### What are the steps to reproduce (after prerequisites)?
- Run on React Native v0.65, call `useKeyboard` within a component that then is destroyed via re-render