### PR TITLE
fix: make reactModalProps optional

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -241,7 +241,7 @@ export interface IProps<ListItem = any> {
   /**
    * Props for the react-native Modal wrapping Modalize
    */
-  reactModalProps: ModalProps;
+  reactModalProps?: ModalProps;
 
   /**
    * Define if the handle on top of the modal is display or not.


### PR DESCRIPTION
After upgrading to 2.0.9 I began receiving TypeScript errors on every use of Modalize in my project.

[This commit](https://github.com/jeremybarbet/react-native-modalize/pull/352/commits/ac5a61efb508572bd3b06ae34da6dcea7908dc8f) marked the `reactModalProps` as required, but they should be optional.