### PR TITLE
fix: Jest - ReactNative.Platform.constants.reactNativeVersion is undefined

### DIFF
--- a/src/utils/devices.ts
+++ b/src/utils/devices.ts
@@ -17,4 +17,4 @@ export const isIphoneX =
     width === 926);
 export const isAndroid = Platform.OS === 'android';
 export const isWeb = Platform.OS === 'web';
-export const isBelowRN65 = Platform.constants?.reactNativeVersion.minor < 65;
+export const isBelowRN65 = Platform.constants?.reactNativeVersion?.minor < 65;


### PR DESCRIPTION
This issue is very similar to the one fixed here: https://github.com/jeremybarbet/react-native-modalize/pull/367
And I personnally thought this would be the exact same issue.

But it seems that using jest and react native jest preset: `Platform.constants` is actually defined ( so adding optional chaining on it have no real impact), but `Platform.constants.reactNativeVersion` is `undefined`.
