### PR TITLE
fix: RN Modalize receive error with RN gesture handler 2.0

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,7 +38,7 @@ import {
 import { IProps, TOpen, TClose, TStyle, IHandles, TPosition } from './options';
 import { useDimensions } from './utils/use-dimensions';
 import { getSpringConfig } from './utils/get-spring-config';
-import { isIphoneX, isIos, isAndroid, isBelowRN65 } from './utils/devices';
+import { isIphoneX, isIos, isAndroid, isBelowRN65, isRNGHVersion2 } from './utils/devices';
 import { invariant } from './utils/invariant';
 import { composeRefs } from './utils/compose-refs';
 import s from './styles';
@@ -775,7 +775,7 @@ const ModalizeBase = (
 
   const renderChildren = (): JSX.Element => {
     const style = adjustToContentHeight ? s.content__adjustHeight : s.content__container;
-
+    const minDistValue = isRNGHVersion2() ? undefined : ACTIVATED;
     return (
       <PanGestureHandler
         ref={panGestureChildrenRef}
@@ -783,6 +783,7 @@ const ModalizeBase = (
         simultaneousHandlers={[nativeViewChildrenRef, tapGestureModalizeRef]}
         shouldCancelWhenOutside={false}
         onGestureEvent={handleGestureEvent}
+        minDist={minDistValue}
         activeOffsetY={ACTIVATED}
         activeOffsetX={ACTIVATED}
         onHandlerStateChange={handleChildren}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -783,7 +783,6 @@ const ModalizeBase = (
         simultaneousHandlers={[nativeViewChildrenRef, tapGestureModalizeRef]}
         shouldCancelWhenOutside={false}
         onGestureEvent={handleGestureEvent}
-        minDist={ACTIVATED}
         activeOffsetY={ACTIVATED}
         activeOffsetX={ACTIVATED}
         onHandlerStateChange={handleChildren}

--- a/src/utils/devices.ts
+++ b/src/utils/devices.ts
@@ -18,3 +18,11 @@ export const isIphoneX =
 export const isAndroid = Platform.OS === 'android';
 export const isWeb = Platform.OS === 'web';
 export const isBelowRN65 = Platform.constants?.reactNativeVersion?.minor < 65;
+export const isRNGHVersion2 = (): boolean => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require('react-native-gesture-handler/src/handlers/gestures/GestureDetector') != null;
+  } catch (ex) {
+    return false;
+  }
+};


### PR DESCRIPTION
Fixing RN Modalize fail to work with RN gesture handler 2.0 because of using minDist with activeOffsetX or activeOffsetY on PanGestureHandler

Fixed #374