### PR TITLE
chore: add an array of middle points to intercept gesture navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### ✨ Improvements
+
+- Add new prop `snapPoints` to receive an array of points instead of a single one ([#395](https://github.com/jeremybarbet/react-native-modalize/pull/395))
+
 ## [2.0.8] - 2020-12-04
 
 ### 👀 Bug Fixes

--- a/docs/PROPS.md
+++ b/docs/PROPS.md
@@ -217,6 +217,16 @@ The value you pass is the height of the modal before being full opened.
 | ------ | -------- |
 | number | No       |
 
+### `snapPoints`
+
+Similar to `snapPoint`, but here you pass an array of numbers that will enable the snapping feature and create intermediate points before opening the modal to full screen.
+
+The values you pass are the height of the modal before being full opened.
+
+| Type  | Required |
+| ----- | -------- |
+| array | No       |
+
 ### `modalHeight`
 
 A number to define the modal's total height.

--- a/src/options.ts
+++ b/src/options.ts
@@ -103,6 +103,11 @@ export interface IProps<ListItem = any> {
   snapPoint?: number;
 
   /**
+   * An array of numbers to enable the snapping feature with intermediate points before opening the modal to full screen.
+   */
+  snapPoints?: number[];
+
+  /**
    * A number to define the modal's total height.
    */
   modalHeight?: number;


### PR DESCRIPTION
This is a Work in Progress to try to address https://github.com/jeremybarbet/react-native-modalize/issues/213, https://github.com/jeremybarbet/react-native-modalize/issues/356 and https://github.com/jeremybarbet/react-native-modalize/issues/297 with an array of `snapPoints` instead of a single value.

This code is not tested yet, it's just an initial "try and error" solution before we move on with a better and optimized code as well.

### How should you test it? 
Clone the branch, `yarn install` and `yarn build` to update your dependencies, link the repo in your base code, and take a moment do comment this PR with your thoughts and improvements

Update your code removing `snapPoint` and adding the new prop with your middle points, something like this;`snapPoints=[150, 300, ....]`