### PR TITLE
fix: gestures not working on react native modal

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,17 @@
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  close_issues:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Close issues that don't follow the issue template
+        uses: lucasbento/auto-close-issues@v1.0.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          closed-issues-label: "incorrect-issue-template"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,6 +33,7 @@ import {
   TapGestureHandler,
   PanGestureHandlerStateChangeEvent,
   TapGestureHandlerStateChangeEvent,
+  GestureHandlerRootView,
 } from 'react-native-gesture-handler';
 
 import { IProps, TOpen, TClose, TStyle, IHandles, TPosition } from './options';
@@ -694,8 +695,10 @@ const ModalizeBase = (
      * Nesting Touchable/ScrollView components with RNGH PanGestureHandler cancels the inner events.
      * Until a better solution lands in RNGH, I will disable the PanGestureHandler for Android only,
      * so inner touchable/gestures are working from the custom components you can pass in.
+     *
+     * This is fixed in RNGH 2 with https://github.com/software-mansion/react-native-gesture-handler/pull/1603
      */
-    if (isAndroid && !panGestureComponentEnabled) {
+    if (isAndroid && !panGestureComponentEnabled && !isRNGH2()) {
       return tag;
     }
 
@@ -983,7 +986,7 @@ const ModalizeBase = (
       visible={isVisible}
       transparent
     >
-      {child}
+      <GestureHandlerRootView style={{ flex: 1 }}>{child}</GestureHandlerRootView>
     </Modal>
   );
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -161,6 +161,7 @@ export interface IProps<ListItem = any> {
 
   /**
    * Define if HeaderComponent/FooterComponent/FloatingComponent should have pan gesture enable (Android specific). When enable it might break touchable inside the view.
+   * Only has effect on react-native-gesture-handler version < 2.0.0
    * @default false
    */
   panGestureComponentEnabled?: boolean;


### PR DESCRIPTION
In react-native-gesture-handler v2 they fix the issue with gestures not working in react native modal. To accomodiate this change we need to wrap the content of the modal with GestureHandlerRootView.

This also fixes the issues with event bubbling so we can disable panGestureComponentEnabled for RNGH v2

see:
https://github.com/software-mansion/react-native-gesture-handler/pull/1603

should fix https://github.com/jeremybarbet/react-native-modalize/issues/380