### PR TITLE
🐛 Remove previous back handler when adding new one

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,17 @@
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  close_issues:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Close issues that don't follow the issue template
+        uses: lucasbento/auto-close-issues@v1.0.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          closed-issues-label: "incorrect-issue-template"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -176,7 +176,7 @@ const ModalizeBase = (
   const nativeViewChildrenRef = React.useRef<NativeViewGestureHandler>(null);
   const contentViewRef = React.useRef<ScrollView | FlatList<any> | SectionList<any>>(null);
   const tapGestureOverlayRef = React.useRef<TapGestureHandler>(null);
-  const backButtonListenerRef = React.useRef<NativeEventSubscription>(null);
+  const backButtonListenerRef = React.useRef<NativeEventSubscription | null>(null);
 
   // We diff and get the negative value only. It sometimes go above 0
   // (e.g. 1.5) and creates the flickering on Modalize for a ms
@@ -228,7 +228,7 @@ const ModalizeBase = (
     const { timing, spring } = openAnimationConfig;
 
     backButtonListenerRef.current?.remove();
-    (backButtonListenerRef as any).current = BackHandler.addEventListener(
+    backButtonListenerRef.current = BackHandler.addEventListener(
       'hardwareBackPress',
       handleBackPress,
     );
@@ -858,6 +858,18 @@ const ModalizeBase = (
   }));
 
   React.useEffect(() => {
+    if (backButtonListenerRef.current) {
+      backButtonListenerRef.current.remove();
+      backButtonListenerRef.current = null;
+
+      backButtonListenerRef.current = BackHandler.addEventListener(
+        'hardwareBackPress',
+        handleBackPress
+      );
+    }
+  },[handleBackPress])
+
+  React.useEffect(() => {
     if (alwaysOpen && (modalHeightValue || adjustToContentHeight)) {
       handleAnimateOpen(alwaysOpen);
     }
@@ -906,7 +918,6 @@ const ModalizeBase = (
     }
 
     return (): void => {
-      backButtonListenerRef.current?.remove();
       beginScrollY.removeListener(beginScrollYListener);
 
       if (isBelowRN65) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -227,6 +227,7 @@ const ModalizeBase = (
   ): void => {
     const { timing, spring } = openAnimationConfig;
 
+    backButtonListenerRef.current?.remove();
     (backButtonListenerRef as any).current = BackHandler.addEventListener(
       'hardwareBackPress',
       handleBackPress,


### PR DESCRIPTION
When open is called multiple times, multiple listeners will be registered, while only the most recent one is stored in the ref. This caused issues where only the most recent one was removed instead of all listeners.

With this fix only a single back handler can be registered, and calling remove will remove the only one registered.