### PR TITLE
Fixed typo with close callback argument

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,4 +14,5 @@ jobs:
         uses: lucasbento/auto-close-issues@v1.0.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-close-message: "@${issue.user.login}: hello! :wave:\n\nThis issue is being automatically closed because it does not follow the issue template."
           closed-issues-label: "incorrect-issue-template"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,17 @@
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  close_issues:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Close issues that don't follow the issue template
+        uses: lucasbento/auto-close-issues@v1.0.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          closed-issues-label: "incorrect-issue-template"

--- a/src/options.ts
+++ b/src/options.ts
@@ -330,5 +330,5 @@ export interface IHandles {
    * If you are using `alwaysOpen` prop, you can supply a `dest` argument to the `close` method to reset it
    * to the initial position `close('alwaysOpen')`, and avoiding to close it completely.
    */
-  close(dest?: TClose): void;
+  close(dest?: TClose, callback?(): void): void;
 }


### PR DESCRIPTION
Fixed TS error `Expected 0-1 arguments, but got 2`, when using the close method with two arguments