### PR TITLE
fix: fixed panGestureAnimatedValue change on content scroll down

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -630,7 +630,7 @@ const ModalizeBase = (
   const handleGestureEvent = Animated.event([{ nativeEvent: { translationY: dragY } }], {
     useNativeDriver: USE_NATIVE_DRIVER,
     listener: ({ nativeEvent: { translationY } }: PanGestureHandlerStateChangeEvent) => {
-      if (panGestureAnimatedValue) {
+      if (panGestureAnimatedValue && !beginScrollYValue) {
         const offset = alwaysOpen ?? snapPoint ?? 0;
         const diff = Math.abs(translationY / (endHeight - offset));
         const y = translationY <= 0 ? diff : 1 - diff;


### PR DESCRIPTION
The issue was described here https://github.com/jeremybarbet/react-native-modalize/issues/471. 
I found out that the modal could be closed by swiping the child scroll (ScrollView, FlatList ...) down only if that child list is on the top and was on the top at the moment when the drag gesture was started. So I added the check in handleGestureEvent that checks if the list was already in the top so the calculation for panGestureAnimatedValue starts. This should be valid as long as panGestureAnimatedValue value does what was described in docs "Animated.Value of the modal opening position between 0 and 1."