### PR TITLE
fix: overlayPress close improvement by correctly running onComplete c…

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -346,7 +346,10 @@ const ModalizeBase = (
             toValue,
             useNativeDriver: USE_NATIVE_DRIVER,
           }),
-    ]).start(() => {
+    ]).start(({ finished }) => {
+      if (!finished) {
+        return;
+      }
       if (onClosed) {
         onClosed();
       }


### PR DESCRIPTION
…allback only when anim is done

If you tap on the overlay it runs the completion closure too eagerly, this change fixes that

[Api Reference](https://reactnative.dev/docs/animated#start)