### PR TITLE
bugfix: Added heights for iPhone 14 Pro and Max in `isIphoneX` helper method

### DIFF
--- a/src/utils/devices.ts
+++ b/src/utils/devices.ts
@@ -14,7 +14,14 @@ export const isIphoneX =
     height === 896 ||
     width === 896 ||
     height === 926 ||
-    width === 926);
+    width === 926 ||
+    // iPhone 14 Pro Viewport Height
+    height === 852 ||
+    width === 852 ||
+    //iPhone 14 Pro Max Viewport Height
+    height === 932 ||
+    width === 932
+  );
 
 export const isAndroid = Platform.OS === 'android';
 export const isWeb = Platform.OS === 'web';


### PR DESCRIPTION
* bugfix: Added heights for iPhone 14 Pro and Max in the `isIphoneX` helper method