### PR TITLE
fix- modal jumping height

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -225,6 +225,7 @@ const ModalizeBase = (
     alwaysOpenValue: number | undefined,
     dest: TOpen = 'default',
   ): void => {
+    dragY.setValue(0);
     const { timing, spring } = openAnimationConfig;
 
     (backButtonListenerRef as any).current = BackHandler.addEventListener(


### PR DESCRIPTION
DragY is being reset somewhere- causes modal to jump around. Workaround is to set it again at the start of `handleAnimateOpen`

https://github.com/jeremybarbet/react-native-modalize/issues/498#issuecomment-1936222274